### PR TITLE
Implements full API and adds tests

### DIFF
--- a/INI.framework Tests/.gitattributes
+++ b/INI.framework Tests/.gitattributes
@@ -1,0 +1,2 @@
+#Make sure our test ini files aren't altered by git
+*.ini binary

--- a/INI.framework Tests/INI_Entry_Tests.m
+++ b/INI.framework Tests/INI_Entry_Tests.m
@@ -1,0 +1,286 @@
+// © 2016 Robert Corrigan
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#import <XCTest/XCTest.h>
+#import "INI.h"
+
+@interface INI_Entry_Tests : XCTestCase
+
+@end
+
+@implementation INI_Entry_Tests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testINIEntry_EntryWithLine_KeyAndValue {
+	NSString *line = @"  username  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"username");
+	XCTAssertEqualObjects(entry.value, @"mirek");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 8);
+
+	XCTAssertEqual(entry.info.value.location, 16);
+	XCTAssertEqual(entry.info.value.length, 5);
+
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_EntryWithLine_KeyWithSpacesAndValue {
+	NSString *line = @"  user name  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"user name");
+	XCTAssertEqualObjects(entry.value, @"mirek");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 9);
+	
+	XCTAssertEqual(entry.info.value.location, 17);
+	XCTAssertEqual(entry.info.value.length, 5);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_EntryWithLine_KeyOnly {
+	NSString *line = @"  username  \t=";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"username");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 8);
+	
+	XCTAssertEqual(entry.info.value.location, 14);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_EntryWithLine_KeyOnlyNoEqualSignTrailing {
+	NSString *line = @"  username  \t";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 0);
+	XCTAssertEqual(entry.info.key.length, 0);
+	
+	XCTAssertEqual(entry.info.value.location, 0);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeOther);
+}
+
+- (void)testINIEntry_EntryWithLine_KeyOnlyNoEqualSign {
+	NSString *line = @"username";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 0);
+	XCTAssertEqual(entry.info.key.length, 0);
+	
+	XCTAssertEqual(entry.info.value.location, 0);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeOther);
+}
+
+- (void)testINIEntry_EntryWithLine_Section {
+	NSString *line = @" [section] ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"section");
+
+	XCTAssertEqual(entry.info.key.location, 0);
+	XCTAssertEqual(entry.info.key.length, 0);
+	
+	XCTAssertEqual(entry.info.value.location, 0);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 2);
+	XCTAssertEqual(entry.info.section.length, 7);
+
+	XCTAssertEqual(entry.type, INIEntryTypeSection);
+}
+
+- (void)testINIEntry_EntryWithLine_Comment {
+	NSString *line = @"# [section] ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 0);
+	XCTAssertEqual(entry.info.key.length, 0);
+	
+	XCTAssertEqual(entry.info.value.location, 0);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeComment);
+}
+
+- (void)testINIEntry_EntryWithLine_Blank {
+	NSString *line = @"";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 0);
+	XCTAssertEqual(entry.info.key.length, 0);
+	
+	XCTAssertEqual(entry.info.value.location, 0);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeOther);
+}
+
+- (void)testINIEntry_SetKey {
+	NSString *line = @"  username  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+
+	NSString *expectedLine = [line stringByReplacingOccurrencesOfString:@"username" withString:@"accountname"];
+
+	entry.key = @"accountname";
+	XCTAssertEqualObjects(entry.line, expectedLine);
+	XCTAssertEqualObjects(entry.key, @"accountname");
+	XCTAssertEqualObjects(entry.value, @"mirek");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 11);
+	
+	XCTAssertEqual(entry.info.value.location, 19);
+	XCTAssertEqual(entry.info.value.length, 5);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_SetKeyBlank_ShouldIgnore {
+	NSString *line = @"  username  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	entry.key = @"";
+	XCTAssertEqualObjects(entry.line, line);
+	XCTAssertEqualObjects(entry.key, @"username");
+	XCTAssertEqualObjects(entry.value, @"mirek");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 8);
+	
+	XCTAssertEqual(entry.info.value.location, 16);
+	XCTAssertEqual(entry.info.value.length, 5);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_SetValue {
+	NSString *line = @"  username  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	NSString *expectedLine = [line stringByReplacingOccurrencesOfString:@"mirek" withString:@"rjcorrig"];
+	
+	entry.value = @"rjcorrig";
+	XCTAssertEqualObjects(entry.line, expectedLine);
+	XCTAssertEqualObjects(entry.key, @"username");
+	XCTAssertEqualObjects(entry.value, @"rjcorrig");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 8);
+	
+	XCTAssertEqual(entry.info.value.location, 16);
+	XCTAssertEqual(entry.info.value.length, 8);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+- (void)testINIEntry_SetValueBlank {
+	NSString *line = @"  username  \t=  mirek  ";
+	INIEntry *entry = [INIEntry entryWithLine: line];
+	
+	NSString *expectedLine = [line stringByReplacingOccurrencesOfString:@"mirek" withString:@""];
+	
+	entry.value = @"";
+	XCTAssertEqualObjects(entry.line, expectedLine);
+	XCTAssertEqualObjects(entry.key, @"username");
+	XCTAssertEqualObjects(entry.value, @"");
+	XCTAssertEqualObjects(entry.section, @"");
+	
+	XCTAssertEqual(entry.info.key.location, 2);
+	XCTAssertEqual(entry.info.key.length, 8);
+	
+	XCTAssertEqual(entry.info.value.location, 18);
+	XCTAssertEqual(entry.info.value.length, 0);
+	
+	XCTAssertEqual(entry.info.section.location, 0);
+	XCTAssertEqual(entry.info.section.length, 0);
+	
+	XCTAssertEqual(entry.type, INIEntryTypeKeyValue);
+}
+
+@end

--- a/INI.framework Tests/INI_File_Tests.m
+++ b/INI.framework Tests/INI_File_Tests.m
@@ -1,0 +1,287 @@
+// © 2016-2017 Robert Corrigan
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#import <XCTest/XCTest.h>
+#import "INI.h"
+
+@interface INI_File_Tests : XCTestCase
+
+@end
+
+@implementation INI_File_Tests
+
+- (void)setUp {
+	[super setUp];
+	
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSURL *source = [bundle URLForResource:@"test_lf" withExtension:@"ini"];
+	NSURL *dest = [[NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES] URLByAppendingPathComponent:@"test_write.ini"];
+	NSFileManager *fm = [[NSFileManager alloc] init];
+	
+	NSError *err;
+	[fm copyItemAtURL:source toURL:dest error:&err];
+	XCTAssertNil(err);
+}
+
+- (void)tearDown {
+  NSURL *dest = [[NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES] URLByAppendingPathComponent:@"test_write.ini"];
+  NSFileManager *fm = [[NSFileManager alloc] init];
+  
+  NSError *err;
+  [fm removeItemAtURL:dest error:&err];
+  XCTAssertNil(err);
+
+	[super tearDown];
+}
+
+- (void)testINIFile_initWithUTF8ContentsOfFile_CRLF {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_crlf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqual([[config entries] count], 10);
+	
+	NSString *contents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&err];
+	XCTAssertEqualObjects(contents, config.contents);
+	XCTAssertEqual(contents.length, config.contents.length);
+	
+	XCTAssertEqualObjects(config.lineEnding, @"\r\n");
+}
+
+- (void)testINIFile_initWithUTF8ContentsOfFile_CR {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_cr" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqual([[config entries] count], 10);
+	
+	NSString *contents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&err];
+	XCTAssertEqualObjects(contents, config.contents);
+	XCTAssertEqual(contents.length, config.contents.length);
+	
+	XCTAssertEqualObjects(config.lineEnding, @"\r");
+}
+
+- (void)testINIFile_initWithUTF8ContentsOfFile_LF {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqual([[config entries] count], 11);
+	
+	NSString *contents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&err];
+	XCTAssertEqualObjects(contents, config.contents);
+	XCTAssertEqual(contents.length, config.contents.length);
+	
+	XCTAssertEqualObjects(config.lineEnding, @"\n");
+}
+
+- (void)testINIFile_sections {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqual([[config sections] count], 2);
+}
+
+- (void)testINIFile_valueForKey_Found {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqualObjects([config valueForKey:@"name"], @"Mirek Rusin");
+}
+
+- (void)testINIFile_valuesForKey_Found {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	NSMutableArray *values = [config valuesForKey:@"name"];
+	XCTAssertEqual([values count], 2);
+	XCTAssertEqualObjects([values objectAtIndex:0], @"Mirek Rusin");
+	XCTAssertEqualObjects([values objectAtIndex:1], @"MirekRusin");
+}
+
+- (void)testINIFile_valueForKey_InSection_Found {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertEqualObjects([config valueForKey:@"name" inSection:@"github"], @"MirekRusin");
+}
+
+- (void)testINIFile_valuesForKey_InSection_Found {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	NSMutableArray *values = [config valuesForKey:@"name" inSection:@"github"];
+	XCTAssertEqual([values count], 1);
+	XCTAssertEqualObjects([values objectAtIndex:0], @"MirekRusin");
+}
+
+- (void)testINIFile_valueForKey_NotFound {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertNil([config valueForKey:@"nam"]);
+}
+
+- (void)testINIFile_valuesForKey_NotFound {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	NSMutableArray *values = [config valuesForKey:@"nam"];
+	XCTAssertEqual([values count], 0);
+}
+
+- (void)testINIFile_valueForKey_InSection_NotFound {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	XCTAssertNil([config valueForKey:@"name" inSection:@"use"]);
+}
+
+- (void)testINIFile_valuesForKey_InSection_NotFound {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	NSMutableArray *values = [config valuesForKey:@"name" inSection:@"use"];
+	XCTAssertEqual([values count], 0);
+}
+
+- (void)testINIFile_setValue_forKey_inSection_NewSectionNewKey {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	[config setValue:@"newValue" forKey:@"newKey" inSection:@"newSection"];
+	XCTAssertEqualObjects([config valueForKey:@"newKey" inSection:@"newSection"], @"newValue");
+}
+
+- (void)testINIFile_setValue_forKey_inSection_ExistingSectionNewKey {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	[config setValue:@"newValue" forKey:@"newKey" inSection:@"github"];
+	XCTAssertEqualObjects([config valueForKey:@"newKey" inSection:@"github"], @"newValue");
+}
+
+- (void)testINIFile_setValue_forKey_inSection_ExistingSectionExistingKey {
+	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+	NSString *path = [bundle pathForResource:@"test_lf" ofType:@"ini"];
+	NSError *err;
+	
+	INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	
+	XCTAssertNil(err);
+	
+	XCTAssertEqualObjects([config valueForKey:@"name" inSection:@"github"], @"MirekRusin");
+	[config setValue:@"rjcorrig" forKey:@"name" inSection:@"github"];
+	XCTAssertEqualObjects([config valueForKey:@"name" inSection:@"github"], @"rjcorrig");
+}
+
+- (void)testINIFile_writeFile {
+  NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"test_write.ini"];
+	NSError *err;
+	
+	INIFile *srcConfig = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	XCTAssertNil(err);
+	XCTAssertNil([srcConfig valueForKey:@"newKey" inSection:@"newSection"]);
+	
+	[srcConfig setValue:@"newValue" forKey:@"newKey" inSection:@"newSection"];
+	XCTAssertEqualObjects([srcConfig valueForKey:@"newKey" inSection:@"newSection"], @"newValue");
+
+	[srcConfig writeToUTF8File:path atomically:YES error:&err];
+	
+	XCTAssertNil(err);
+
+	INIFile *destConfig = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	XCTAssertEqualObjects(destConfig.contents, srcConfig.contents);
+}
+
+- (void)testINIFile_writeFile_noPath {
+	INIFile *srcConfig = [[INIFile alloc] init];
+	XCTAssertNil([srcConfig valueForKey:@"newKey" inSection:@"newSection"]);
+	
+	[srcConfig setValue:@"newValue" forKey:@"newKey" inSection:@"newSection"];
+	XCTAssertEqualObjects([srcConfig valueForKey:@"newKey" inSection:@"newSection"], @"newValue");
+	
+	NSError *err;
+	[srcConfig writeToUTF8File:srcConfig.path atomically:YES error:&err];
+	
+	XCTAssertNotNil(err);
+}
+
+- (void)testINIFile_writeFile_autosave {
+  NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"test_write.ini"];
+	NSError *err;
+	
+	INIFile *srcConfig = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	XCTAssertNil(err);
+	XCTAssertNil([srcConfig valueForKey:@"newKey" inSection:@"newSection"]);
+	
+	srcConfig.autosave = YES;
+	[srcConfig setValue:@"newValue" forKey:@"newKey" inSection:@"newSection"];
+	XCTAssertEqualObjects([srcConfig valueForKey:@"newKey" inSection:@"newSection"], @"newValue");
+	
+	INIFile *destConfig = [[INIFile alloc] initWithUTF8ContentsOfFile:path error:&err];
+	XCTAssertEqualObjects(destConfig.contents, srcConfig.contents);
+}
+
+@end

--- a/INI.framework Tests/Info.plist
+++ b/INI.framework Tests/Info.plist
@@ -3,26 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>

--- a/INI.framework Tests/test_cr.ini
+++ b/INI.framework Tests/test_cr.ini
@@ -1,0 +1,1 @@
+[user]	name = Mirek Rusin	email = mirek [at] me [dot] com#Next line intentionally blank[github]	user = mirek	token = 9199...#Here's a comment

--- a/INI.framework Tests/test_crlf.ini
+++ b/INI.framework Tests/test_crlf.ini
@@ -1,0 +1,9 @@
+[user]
+	name = Mirek Rusin
+	email = mirek [at] me [dot] com
+#Next line intentionally blank
+
+[github]
+	user = mirek
+	token = 9199...
+#Here's a comment

--- a/INI.framework Tests/test_lf.ini
+++ b/INI.framework Tests/test_lf.ini
@@ -1,0 +1,10 @@
+[user]
+	name = Mirek Rusin
+	email = mirek [at] me [dot] com
+#Next line intentionally blank
+
+[github]
+	name = MirekRusin
+	user = mirek
+	token = 9199...
+#Here's a comment

--- a/INI.xcodeproj/project.pbxproj
+++ b/INI.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
+		EB0DD7D51DCE615D00D7BFC1 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB0DD7D41DCE615D00D7BFC1 /* AppKit.framework */; };
 		EB41D0D111CAF3930018876A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0867D69BFE84028FC02AAC07 /* Foundation.framework */; };
 		EB41D1AF11CAF3E50018876A /* INI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* INI.framework */; };
 		EB41D1B711CAF4070018876A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EB41D1B611CAF4070018876A /* main.m */; };
@@ -18,6 +19,12 @@
 		EB41D1CC11CAF4750018876A /* INIFile.m in Sources */ = {isa = PBXBuildFile; fileRef = EB41D1C811CAF4750018876A /* INIFile.m */; };
 		EB41D1D411CAF5010018876A /* Readme.mkdn in Resources */ = {isa = PBXBuildFile; fileRef = EB41D1D311CAF5010018876A /* Readme.mkdn */; };
 		EB41D24211CCB4E80018876A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EB41D1B611CAF4070018876A /* main.m */; };
+		EB84E90A1DBD6564006B1E6E /* INI_Entry_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB84E9091DBD6564006B1E6E /* INI_Entry_Tests.m */; };
+		EB84E90C1DBD6564006B1E6E /* INI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* INI.framework */; };
+		EB84E9131DBD7A5E006B1E6E /* INI_File_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB84E9121DBD7A5E006B1E6E /* INI_File_Tests.m */; };
+		EB84E9151DBD7AF6006B1E6E /* test_crlf.ini in Resources */ = {isa = PBXBuildFile; fileRef = EB84E9141DBD7AF6006B1E6E /* test_crlf.ini */; };
+		EBF4C5FD1DC03FE00032A9A8 /* test_lf.ini in Resources */ = {isa = PBXBuildFile; fileRef = EBF4C5FC1DC03FE00032A9A8 /* test_lf.ini */; };
+		EBF4C5FF1DC040390032A9A8 /* test_cr.ini in Resources */ = {isa = PBXBuildFile; fileRef = EBF4C5FE1DC040390032A9A8 /* test_cr.ini */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,7 +32,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 8DC2EF4F0486A6940098B216 /* INI.framework */;
+			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
+			remoteInfo = INI.framework;
+		};
+		EB84E90D1DBD6564006B1E6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
 			remoteInfo = INI.framework;
 		};
 /* End PBXContainerItemProxy section */
@@ -36,14 +50,22 @@
 		32DBCF5E0370ADEE00C91783 /* INI_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INI_Prefix.pch; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* INI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = INI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB0DD7D41DCE615D00D7BFC1 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		EB41D1A911CAF3DB0018876A /* ini */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ini; sourceTree = BUILT_PRODUCTS_DIR; };
-		EB41D1B611CAF4070018876A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		EB41D1B811CAF4320018876A /* INI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INI.h; sourceTree = "<group>"; };
-		EB41D1C511CAF4750018876A /* INIEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INIEntry.h; sourceTree = "<group>"; };
-		EB41D1C611CAF4750018876A /* INIEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = INIEntry.m; sourceTree = "<group>"; };
-		EB41D1C711CAF4750018876A /* INIFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INIFile.h; sourceTree = "<group>"; };
-		EB41D1C811CAF4750018876A /* INIFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = INIFile.m; sourceTree = "<group>"; };
+		EB41D1B611CAF4070018876A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; tabWidth = 2; };
+		EB41D1B811CAF4320018876A /* INI.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = INI.h; sourceTree = "<group>"; tabWidth = 2; };
+		EB41D1C511CAF4750018876A /* INIEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = INIEntry.h; sourceTree = "<group>"; tabWidth = 2; };
+		EB41D1C611CAF4750018876A /* INIEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = INIEntry.m; sourceTree = "<group>"; tabWidth = 2; };
+		EB41D1C711CAF4750018876A /* INIFile.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = INIFile.h; sourceTree = "<group>"; tabWidth = 2; };
+		EB41D1C811CAF4750018876A /* INIFile.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = INIFile.m; sourceTree = "<group>"; tabWidth = 2; };
 		EB41D1D311CAF5010018876A /* Readme.mkdn */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Readme.mkdn; sourceTree = "<group>"; };
+		EB84E9071DBD6564006B1E6E /* INI.framework Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "INI.framework Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB84E9091DBD6564006B1E6E /* INI_Entry_Tests.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = INI_Entry_Tests.m; sourceTree = "<group>"; tabWidth = 2; };
+		EB84E90B1DBD6564006B1E6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EB84E9121DBD7A5E006B1E6E /* INI_File_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = INI_File_Tests.m; sourceTree = "<group>"; tabWidth = 2; };
+		EB84E9141DBD7AF6006B1E6E /* test_crlf.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 2; path = test_crlf.ini; sourceTree = "<group>"; };
+		EBF4C5FC1DC03FE00032A9A8 /* test_lf.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; path = test_lf.ini; sourceTree = "<group>"; };
+		EBF4C5FE1DC040390032A9A8 /* test_cr.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 1; path = test_cr.ini; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB0DD7D51DCE615D00D7BFC1 /* AppKit.framework in Frameworks */,
 				EB41D0D111CAF3930018876A /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -63,6 +86,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EB84E9041DBD6564006B1E6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB84E90C1DBD6564006B1E6E /* INI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -71,6 +102,7 @@
 			children = (
 				8DC2EF5B0486A6940098B216 /* INI.framework */,
 				EB41D1A911CAF3DB0018876A /* ini */,
+				EB84E9071DBD6564006B1E6E /* INI.framework Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -83,7 +115,9 @@
 				32C88DFF0371C24200C91783 /* Other Sources */,
 				089C1665FE841158C02AAC07 /* Resources */,
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
+				EB84E9081DBD6564006B1E6E /* INI.framework Tests */,
 				034768DFFF38A50411DB9C8B /* Products */,
+				EB0DD7D31DCE615D00D7BFC1 /* Frameworks */,
 			);
 			name = INI;
 			sourceTree = "<group>";
@@ -142,12 +176,33 @@
 			name = "Other Sources";
 			sourceTree = "<group>";
 		};
+		EB0DD7D31DCE615D00D7BFC1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EB0DD7D41DCE615D00D7BFC1 /* AppKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		EB41D1B211CAF3EC0018876A /* ini */ = {
 			isa = PBXGroup;
 			children = (
 				EB41D1B611CAF4070018876A /* main.m */,
 			);
 			name = ini;
+			sourceTree = "<group>";
+		};
+		EB84E9081DBD6564006B1E6E /* INI.framework Tests */ = {
+			isa = PBXGroup;
+			children = (
+				EB84E9091DBD6564006B1E6E /* INI_Entry_Tests.m */,
+				EB84E90B1DBD6564006B1E6E /* Info.plist */,
+				EB84E9121DBD7A5E006B1E6E /* INI_File_Tests.m */,
+				EB84E9141DBD7AF6006B1E6E /* test_crlf.ini */,
+				EBF4C5FC1DC03FE00032A9A8 /* test_lf.ini */,
+				EBF4C5FE1DC040390032A9A8 /* test_cr.ini */,
+			);
+			path = "INI.framework Tests";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -202,14 +257,45 @@
 			productReference = EB41D1A911CAF3DB0018876A /* ini */;
 			productType = "com.apple.product-type.tool";
 		};
+		EB84E9061DBD6564006B1E6E /* INI.framework Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB84E9111DBD6564006B1E6E /* Build configuration list for PBXNativeTarget "INI.framework Tests" */;
+			buildPhases = (
+				EB84E9031DBD6564006B1E6E /* Sources */,
+				EB84E9041DBD6564006B1E6E /* Frameworks */,
+				EB84E9051DBD6564006B1E6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EB84E90E1DBD6564006B1E6E /* PBXTargetDependency */,
+			);
+			name = "INI.framework Tests";
+			productName = "INI.framework Tests";
+			productReference = EB84E9071DBD6564006B1E6E /* INI.framework Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				TargetAttributes = {
+					EB84E9061DBD6564006B1E6E = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "INI" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* INI */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
@@ -217,6 +303,7 @@
 			targets = (
 				8DC2EF4F0486A6940098B216 /* INI.framework */,
 				EB41D1A811CAF3DB0018876A /* ini */,
+				EB84E9061DBD6564006B1E6E /* INI.framework Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -228,6 +315,16 @@
 			files = (
 				8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */,
 				EB41D1D411CAF5010018876A /* Readme.mkdn in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB84E9051DBD6564006B1E6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBF4C5FD1DC03FE00032A9A8 /* test_lf.ini in Resources */,
+				EB84E9151DBD7AF6006B1E6E /* test_crlf.ini in Resources */,
+				EBF4C5FF1DC040390032A9A8 /* test_cr.ini in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -252,6 +349,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EB84E9031DBD6564006B1E6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB84E9131DBD7A5E006B1E6E /* INI_File_Tests.m in Sources */,
+				EB84E90A1DBD6564006B1E6E /* INI_Entry_Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -259,6 +365,11 @@
 			isa = PBXTargetDependency;
 			target = 8DC2EF4F0486A6940098B216 /* INI.framework */;
 			targetProxy = EB41D1AD11CAF3E10018876A /* PBXContainerItemProxy */;
+		};
+		EB84E90E1DBD6564006B1E6E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8DC2EF4F0486A6940098B216 /* INI.framework */;
+			targetProxy = EB84E90D1DBD6564006B1E6E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -278,6 +389,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -290,7 +402,10 @@
 				GCC_PREFIX_HEADER = INI_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mirekrusin.${PRODUCT_NAME:rfc1034Identifier}";
 				PRODUCT_NAME = INI;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -299,6 +414,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -308,7 +424,10 @@
 				GCC_PREFIX_HEADER = INI_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mirekrusin.${PRODUCT_NAME:rfc1034Identifier}";
 				PRODUCT_NAME = INI;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;
@@ -316,26 +435,69 @@
 		1DEB91B208733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		1DEB91B308733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -385,6 +547,66 @@
 			};
 			name = Release;
 		};
+		EB84E90F1DBD6564006B1E6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "INI.framework Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rohrer.INI-framework-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		EB84E9101DBD6564006B1E6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "INI.framework Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rohrer.INI-framework-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -411,6 +633,15 @@
 			buildConfigurations = (
 				EB41D1AB11CAF3DC0018876A /* Debug */,
 				EB41D1AC11CAF3DC0018876A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EB84E9111DBD6564006B1E6E /* Build configuration list for PBXNativeTarget "INI.framework Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB84E90F1DBD6564006B1E6E /* Debug */,
+				EB84E9101DBD6564006B1E6E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/INIEntry.h
+++ b/INIEntry.h
@@ -1,4 +1,5 @@
-// © 2010 Mirek Rusin
+// Original code © 2010 Mirek Rusin
+// Modified code © 2016 Robert Corrigan
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -23,7 +24,7 @@ typedef struct {
   INIEntryType type;
 }
 
-@property (nonatomic, retain) NSString *line;
+@property (nonatomic, strong) NSString *line;
 @property (assign) INIEntryInfo info;
 @property (assign) INIEntryType type;
 

--- a/INIEntry.m
+++ b/INIEntry.m
@@ -1,4 +1,5 @@
-// © 2010 Mirek Rusin
+// Original code © 2010 Mirek Rusin
+// Modified code © 2016 Robert Corrigan
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -32,8 +33,6 @@
 }
 
 - (void) setLine: (NSString *) line_ {
-  if (line)
-    [line release];
   line = line_;
   [self parse];
 }
@@ -43,127 +42,82 @@
   info.key = NSMakeRange(0, 0);
   info.value = NSMakeRange(0, 0);
   type = INIEntryTypeOther;
-  
-  if (line) {
-    int n = line.length;
-    int j;
-    char state = ' ';
-    for (int i = 0; i < n; i++) {
-      switch (state) {
-          
-        // Whitespace at the beginning of line or initial state
-        case ' ': 
-          switch ([line characterAtIndex: i]) {
-              
-            case ' ':
-            case '\t':
-              break;
-              
-            case '[':
-              state = '[';
-              info.section.location = i + 1;
-              type = INIEntryTypeSection;
-              break;
-            
-            case '#':
-            case ';':
-              state = '.';
-              type = INIEntryTypeComment;
-              break;
-              
-            default:
-              state = 'k';
-              info.key.location = i;
-              type = INIEntryTypeKeyValue;
-              break;
-          }
-          break;
-          
-        // Section
-        case '[':
-          switch ([line characterAtIndex: i]) {
-            case ']':
-              info.section.length = i - info.section.location;
-              state = '.';
-              break;
-          }
-          break;
-          
-        // Key
-        case 'k':
-          switch ([line characterAtIndex: i]) {
-            case ' ':
-              // let's look ahead to see if it's the end of the key or just a key with a space in the middle
-              for (j = i; j < n && ([line characterAtIndex: j] == ' ' || [line characterAtIndex: j] == '\t'); j++) {}
-              if (j == n) {
-                // malformed entry, we were looking for = sign after the key and reached end of the line
-                state = '.';
-              } else {
-                if ([line characterAtIndex: j] == '=') {
-                  // the key finished at i - 1 (before this whitespace), there were just whitespaces before = sign
-                  info.key.length = i - info.key.location;
-                  // ...let's skip all those whitespaces, equal sign and all whitespaces after the sign
-                  // and jump straight to 'v'alue state
-                  for (j = j + 1; j < n && ([line characterAtIndex: j] == ' ' || [line characterAtIndex: j] == '\t'); j++) {}
-                  i = j - 1;
-                  state = 'v';
-                  info.value.location = j;
-                } else {
-                  // we're still in the key with the whitespaces in the middle
-                  // let's skip them and continue inside 'k'ey state
-                  i = j - 1;
-                }
-              }
-              break;
-          }
-          break;
-          
-        // Value
-        case 'v':
-          if (i == n - 1) {
-            // it's the last char
-            info.value.length = (i + 1) - info.value.location;
-            state = '.';
-          } else {
-            // it's not the last char
-            switch ([line characterAtIndex: i]) {
-              case ' ':
-                // are those white spaces to ignore just before the end of line?
-                for (j = i; j < n && ([line characterAtIndex: j] == ' ' || [line characterAtIndex: j] == '\t'); j++) {}
-                if (j == n) {
-                  // ...yep, we've got the value - capture it without the whitespaces at the end and go to '.'final state
-                  info.value.length = i - info.value.location;
-                  state = '.';
-                }
-                break;
-            }
-          }
-          break;
-        
-        // Fin
-        case '.':
-          i = n;
-          break;
-        
-      }
-    }
-    
-    assert(state == '.');
-  }
+	
+	NSError *error;
+	NSRegularExpression *regex;
+	NSRange lineRange = NSMakeRange(0, [self.line length]);
+
+	// Key-value pair
+	regex = [NSRegularExpression
+		 regularExpressionWithPattern:@"^\\s*([^=;#\\r\\n]+?)\\s*=\\s*([^;#\\r\\n]*)\\s*"
+		 options:0
+		 error:&error];
+	
+	if (regex) {
+		NSTextCheckingResult *match = [regex firstMatchInString:self.line options:0 range:lineRange];
+		if (match) {
+			info.key = [match rangeAtIndex:1];
+			info.value = [match rangeAtIndex:2];
+			
+			// Trim info.value.length to remove trailing spaces
+			NSString *valueTrim = [self.line substringWithRange:info.value];
+			valueTrim = [valueTrim stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+			info.value.length = [valueTrim length];
+			
+			type = INIEntryTypeKeyValue;
+			return;
+		}
+	}
+
+	// Section
+	regex = [NSRegularExpression
+		 regularExpressionWithPattern:@"^\\s*\\[([^\\]\\r\\n]+)]\\s*"
+		 options:0
+		 error:&error];
+	
+	if (regex) {
+		NSTextCheckingResult *match = [regex firstMatchInString:self.line options:0 range:lineRange];
+		if (match) {
+			info.section = [match rangeAtIndex:1];
+			type = INIEntryTypeSection;
+			return;
+		}
+	}
+	
+	// Comment
+	regex = [NSRegularExpression
+		 regularExpressionWithPattern:@"^\\s*[;#]+"
+		 options:0
+		 error:&error];
+	
+	if (regex) {
+		NSTextCheckingResult *match = [regex firstMatchInString:self.line options:0 range:lineRange];
+		if (match) {
+			type = INIEntryTypeComment;
+			return;
+		}
+	}
+	
 }
 
 - (NSString *) key {
   return [line substringWithRange: info.key];
 }
 
-- (void) setKey: (NSString *) key {
+- (void) setKey: (NSString *) key_ {
+	if ([[key_ stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] length]) {
+		line = [line stringByReplacingOccurrencesOfString:self.key withString:key_];
+		[self parse];
+	}
 }
 
 - (NSString *) value {
   return [line substringWithRange: info.value];
 }
 
-- (void) setValue: (NSString *) value {
+- (void) setValue: (NSString *) value_ {
+	line = [line stringByReplacingOccurrencesOfString:self.value withString:value_];
+	[self parse];
 }
 
 - (NSString *) section {

--- a/INIFile.h
+++ b/INIFile.h
@@ -1,4 +1,5 @@
-// © 2010 Mirek Rusin
+// Original code © 2010 Mirek Rusin
+// Modified code © 2016 Robert Corrigan
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -14,15 +15,21 @@
 // License: Apache 2.0 License
 //
 @interface INIFile : NSObject {
-  NSMutableArray *entries;
 }
 
-@property (nonatomic, retain) NSMutableArray *entries;
-@property (assign, readwrite) NSString *contents;
+@property (nonatomic, strong) NSMutableArray *entries;
+@property (copy) NSString *contents;
+
+@property (weak, readonly) NSString *lineEnding;
+@property (copy) NSString *path;
+@property (assign) NSStringEncoding encoding;
+@property (assign) BOOL autosave;
 
 - (id) initWithUTF8ContentsOfFile: (NSString *) path error: (NSError **) error;
 - (id) initWithContentsOfFile: (NSString *) path encoding: (NSStringEncoding) encoding error: (NSError **) error;
 
+- (BOOL) writeToFile: (NSString *) path atomically:(BOOL)useAuxiliaryFile encoding:(NSStringEncoding)enc error:(NSError **)error;
+- (BOOL) writeToUTF8File: (NSString *) path atomically:(BOOL)useAuxiliaryFile error:(NSError **)error;
 
 - (NSIndexSet *) sectionIndexes;
 - (NSArray *) sections;
@@ -32,5 +39,7 @@
 
 - (NSString *) valueForKey: (NSString *) key inSection: (NSString *) section;
 - (NSMutableArray *) valuesForKey: (NSString *) key inSection: (NSString *) section;
+
+- (void) setValue: (NSString *) value forKey: (NSString *) key inSection: (NSString *) section;
 
 @end

--- a/INIFile.m
+++ b/INIFile.m
@@ -1,69 +1,194 @@
-// © 2010 Mirek Rusin
+// Original code © 2010 Mirek Rusin
+// Modified code © 2016 Robert Corrigan
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 #import "INIFile.h"
 
-@implementation INIFile
+@implementation INIFile {
+	NSArrayController *entryController;
+}
 
 @synthesize entries;
-@synthesize contents;
+@synthesize lineEnding = _lineEnding;
+@synthesize path;
+@synthesize encoding;
+@synthesize autosave;
 
 - (id) init {
   if (self = [super init]) {
-    self.entries = [NSMutableArray array];
+		entryController = [[NSArrayController alloc] init];
+		self.entries = [NSMutableArray array];
+		[entryController addObserver:self forKeyPath:@"arrangedObjects" options:0 context:nil];
+		[entryController addObserver:self forKeyPath:@"arrangedObjects.line" options:0 context:nil];
+		
+		self.encoding = NSUTF8StringEncoding;
+		self.autosave = NO;
   }
   return self;
 }
 
-- (id) initWithUTF8ContentsOfFile: (NSString *) path error: (NSError **) error {
+- (void) dealloc {
+	[entryController removeObserver:self forKeyPath:@"arrangedObjects.line"];
+	[entryController removeObserver:self forKeyPath:@"arrangedObjects"];
+}
+
+- (void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+	if (autosave) {
+		NSError *err;
+		if ([self writeToFile:self.path atomically:YES encoding:self.encoding error:&err]) {
+			NSLog(@"Autosave succeeded");
+		} else {
+			NSLog(@"Autosave failed");
+		}
+	}
+}
+
+- (id) initWithUTF8ContentsOfFile: (NSString *) path_ error: (NSError **) error {
+  self = [self initWithContentsOfFile:path_ encoding:NSUTF8StringEncoding error:error];
+  return self;
+}
+
+- (id) initWithContentsOfFile: (NSString *) path_ encoding: (NSStringEncoding) encoding_ error: (NSError **) error {
   if (self = [self init]) {
-    self.contents = [NSString stringWithContentsOfFile: path encoding: NSUTF8StringEncoding error: error];
+    self.contents = [NSString stringWithContentsOfFile: path_ encoding: encoding_ error: error];
+    self.encoding = encoding_;
+    self.path = path_;
   }
   return self;
 }
 
-- (id) initWithContentsOfFile: (NSString *) path encoding: (NSStringEncoding) encoding error: (NSError **) error {
-  if (self = [self init]) {
-    self.contents = [NSString stringWithContentsOfFile: path encoding: encoding error: error];
+- (BOOL) writeToFile: (NSString *) path_ atomically:(BOOL)useAuxiliaryFile encoding:(NSStringEncoding)enc error:(NSError **)error {
+	
+	return [self.contents writeToFile:path_ atomically:useAuxiliaryFile encoding:enc error:error];
+}
+
+- (BOOL) writeToUTF8File: (NSString *) path_ atomically:(BOOL)useAuxiliaryFile error:(NSError **)error {
+
+	return [self writeToFile:path_ atomically:useAuxiliaryFile encoding:NSUTF8StringEncoding error:error];
+}
+
+- (void) setEntries:(NSMutableArray *)entries_ {
+	entries = entries_;
+	[entryController setContent:entries];
+}
+
+- (NSString*) contents {
+  NSMutableString *contents_ = [[NSMutableString alloc] init];
+
+  for (int i = 0; i < [entryController.arrangedObjects count]; i++) {
+    INIEntry *entry = [entryController.arrangedObjects objectAtIndex:i];
+    [contents_ appendFormat:@"%@%@", entry.line, (i < [entryController.arrangedObjects count] -1) ? _lineEnding : @""];
   }
-  return self;
+
+  return contents_;
 }
 
 - (void) setContents: (NSString *) contents_ {
-  self.entries = [NSMutableArray array];
-  for (NSString *line in [contents_ componentsSeparatedByCharactersInSet: [NSCharacterSet newlineCharacterSet]]) {
-    [self.entries addObject: [[INIEntry alloc] initWithLine: line]];
+	self.entries = [NSMutableArray array];
+
+  // Determine newline: LF, CR, or CRLF
+  NSRange firstLineEnd = [contents_ rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
+  if ([[contents_ substringWithRange:firstLineEnd] isEqualToString:@"\n"]) {
+    _lineEnding = @"\n";
+  } else {
+    NSRange lineEndTest = NSMakeRange(firstLineEnd.location, 2);
+    NSString *newLinee = [contents_ substringWithRange:lineEndTest];
+    if ([newLinee isEqualToString:@"\r\n"]) {
+      _lineEnding = @"\r\n";
+    } else {
+      _lineEnding = @"\r";
+    }
+  }
+	
+  for (NSString *line in [contents_ componentsSeparatedByString:_lineEnding]) {
+    [entryController addObject: [[INIEntry alloc] initWithLine: line]];
   }
 }
 
 - (NSString *) valueForKey: (NSString *) key {
-  return nil;
+  NSArray *values = [self valuesForKey: key];
+    if ([values count] > 0) {
+      return [values objectAtIndex:0];
+    } else {
+      return nil;
+    }
 }
 
 - (NSMutableArray *) valuesForKey: (NSString *) key {
-  return [NSMutableArray array];
+  NSMutableArray *values = [NSMutableArray array];
+  for (INIEntry *entry in entryController.arrangedObjects) {
+    if ([entry.key isEqualToString:key]) {
+      [values addObject:entry.value];
+    }
+  }
+  return values;
 }
 
 - (NSString *) valueForKey: (NSString *) key inSection: (NSString *) section {
-  return [[self valuesForKey: key inSection: section] objectAtIndex: 0];
+  NSArray *values = [self valuesForKey: key inSection: section];
+  if ([values count] > 0) {
+    return [values objectAtIndex:0];
+  } else {
+    return nil;
+  }
 }
 
 - (NSMutableArray *) valuesForKey: (NSString *) key inSection: (NSString *) section {
-  return [NSMutableArray array];
+  NSMutableArray *values = [NSMutableArray array];
+  NSString *currentSection = nil;
+
+  for (INIEntry *entry in entryController.arrangedObjects) {
+    if ([entry.section isEqualToString:section]) {
+      currentSection = entry.section;
+    }
+    if ([entry.key isEqualToString:key] && [currentSection isEqualToString:section]) {
+      [values addObject:entry.value];
+    }
+  }
+  return values;
 }
 
 - (void) setValue: (NSString *) value forKey: (NSString *) key inSection: (NSString *) section {
+	INIEntry *updatingEntry = nil;
+	NSString *currentSection = nil;
+	NSInteger sectionIndex = -1;
+	
+	// Find the section and entry to modify
+	for (INIEntry *entry in entryController.arrangedObjects) {
+		if ([entry.section isEqualToString:section]) {
+			currentSection = entry.section;
+			sectionIndex = [entryController.arrangedObjects indexOfObject:entry];
+		}
+		if ([entry.key isEqualToString:key] && [currentSection isEqualToString:section]) {
+			updatingEntry = entry;
+			break;
+		}
+	}
+
+	if (updatingEntry) {
+		updatingEntry.value = value;
+		return;
+	}
+
+	if (sectionIndex < 0) {
+		INIEntry *newSection = [INIEntry entryWithLine:[NSString stringWithFormat:@"[%@]", section]];
+		[entryController addObject:newSection];
+		sectionIndex = [entryController.arrangedObjects count] - 1;
+	}
+	
+	updatingEntry = [INIEntry entryWithLine:[NSString stringWithFormat:@"%@ = %@", key, value]];
+	[entryController insertObject:updatingEntry atArrangedObjectIndex:sectionIndex+1];
 }
 
 - (NSIndexSet *) sectionIndexes {
-  return [self.entries indexesOfObjectsPassingTest: ^(id entry, NSUInteger index, BOOL *stop) {
-    return (BOOL)((INIEntry *)[entry entryType] == INIEntryTypeSection);
+  return [entryController.arrangedObjects indexesOfObjectsPassingTest: ^(id entry, NSUInteger index, BOOL *stop) {
+    return (BOOL)([(INIEntry *)entry type] == INIEntryTypeSection);
   }];
 }
 
 - (NSArray *) sections {
-  return [self.entries objectsAtIndexes: [self sectionIndexes]];
+  return [entryController.arrangedObjects objectsAtIndexes: [self sectionIndexes]];
 }
 
 @end

--- a/main.m
+++ b/main.m
@@ -6,32 +6,39 @@
 #import "INI.h"
 
 int main(int argc, char** argv) {
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  @autoreleasepool {
   
-  INIEntry *entry;
-  
-  entry = [INIEntry entryWithLine: @"  username  \t=  mirek  "];
-  for (int i = 0; i < entry.line.length; i++)
-    printf("%i", i % 10);
-  printf("\n%s\nsection: %i:%i\nkey: %i:%i\nvalue: %i:%i",
-         [entry.line UTF8String],
-         (int)entry.info.section.location, (int)entry.info.section.length,
-         (int)entry.info.key.location, (int)entry.info.key.length,
-         (int)entry.info.value.location, (int)entry.info.value.length);
-  printf("\nkey '%s' is value '%s' section '%s'\n", [entry.key UTF8String], [entry.value UTF8String], [entry.section UTF8String]);
+    INIEntry *entry;
+    
+    entry = [INIEntry entryWithLine: @"  username  \t=  mirek  "];
+    for (int i = 0; i < entry.line.length; i++)
+      printf("%i", i % 10);
+    printf("\n%s\nsection: %i:%i\nkey: %i:%i\nvalue: %i:%i",
+           [entry.line UTF8String],
+           (int)entry.info.section.location, (int)entry.info.section.length,
+           (int)entry.info.key.location, (int)entry.info.key.length,
+           (int)entry.info.value.location, (int)entry.info.value.length);
+    printf("\nkey '%s' is value '%s' section '%s'\n", [entry.key UTF8String], [entry.value UTF8String], [entry.section UTF8String]);
 
-  printf("\n");
-  entry.line = @" [section] ";
+    printf("\n");
+    entry.line = @" [section] ";
+    
+    for (int i = 0; i < entry.line.length; i++)
+      printf("%i", i % 10);
+    printf("\n%s\nsection: %i:%i\nkey: %i:%i\nvalue: %i:%i",
+           [entry.line UTF8String],
+           (int)entry.info.section.location, (int)entry.info.section.length,
+           (int)entry.info.key.location, (int)entry.info.key.length,
+           (int)entry.info.value.location, (int)entry.info.value.length);
+    printf("\nkey '%s' is value '%s' section '%s'\n", [entry.key UTF8String], [entry.value UTF8String], [entry.section UTF8String]);
+	
+    NSError *err;
+    NSString *path = [@"~/.gitconfig" stringByExpandingTildeInPath];
+    INIFile *config = [[INIFile alloc] initWithUTF8ContentsOfFile: path error: &err];
+    NSString *token = [config valueForKey: @"name" inSection: @"user"];
+    NSString *user = [config valueForKey: @"email" inSection: @"user"];
+    NSLog(@"GitHub token %@ for user %@", token, user);
   
-  for (int i = 0; i < entry.line.length; i++)
-    printf("%i", i % 10);
-  printf("\n%s\nsection: %i:%i\nkey: %i:%i\nvalue: %i:%i",
-         [entry.line UTF8String],
-         (int)entry.info.section.location, (int)entry.info.section.length,
-         (int)entry.info.key.location, (int)entry.info.key.length,
-         (int)entry.info.value.location, (int)entry.info.value.length);
-  printf("\nkey '%s' is value '%s' section '%s'\n", [entry.key UTF8String], [entry.value UTF8String], [entry.section UTF8String]);
-  
-  [pool drain];
+  }
   return 0;
 }


### PR DESCRIPTION
Hi Mirek, I was looking for a Mac library to help me read Windows-based INI files in a Mac environment and found your project. Even though it was incomplete, it had the best API of any similar project, so I figured I'd flesh it out for you.

INI.framework now:
- Handles blank lines and values
- Handles malformed entries
- Detects and handles various newline characters (CR, LF or CRLF)
- Implements value(s)ForKey:(inSection:) methods ( fix #1 )
- Implements setKey: and setValue: methods
- Implements writeFile method with autosave
- Uses more robust regex-based entry parsing
- Adds unit testing for all of the above

I hope you like it.